### PR TITLE
fix linked asset path for reveal files

### DIFF
--- a/source/_includes/reveal.njk
+++ b/source/_includes/reveal.njk
@@ -1,6 +1,6 @@
 {%- macro reveal(slides)-%}
 
-	<script src="/_assets/reveal/dist/reveal.js"></script>
+	<script src="/_assets/reveal/reveal.js"></script>
 	<script src="/_assets/reveal/plugin/highlight/highlight.js"></script>
 	<script src="/_assets/reveal/plugin/markdown/markdown.js"></script>
 	<script src="/_assets/reveal/plugin/notes/notes.js"></script>

--- a/source/_layouts/default.njk
+++ b/source/_layouts/default.njk
@@ -12,9 +12,9 @@
 	-%}
 
 	{%- if class == 'presentation' -%}
-		<link rel="stylesheet" href="/_assets/reveal/dist/reset.css">
-		<link rel="stylesheet" href="/_assets/reveal/dist/reveal.css">
-		<link rel="stylesheet" href="/_assets/reveal/dist/theme/{{- theme if theme else 'serif' -}}.css">
+		<link rel="stylesheet" href="/_assets/reveal/reset.css">
+		<link rel="stylesheet" href="/_assets/reveal/reveal.css">
+		<link rel="stylesheet" href="/_assets/reveal/theme/{{- theme if theme else 'serif' -}}.css">
 		<link rel="stylesheet" href="/_assets/reveal/plugin/highlight/monokai.css">
 	{%- else -%}
 		<link rel="stylesheet" href="/_assets/css/style.css">


### PR DESCRIPTION
`<link>` and `<script>` had an incorrect path for the reveal.js files -- they still had `/dist/` in them, and that isn't needed.